### PR TITLE
Notify PR owner of round robin assignment

### DIFF
--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -166,7 +166,7 @@ module Lita
 
           pr_owner = find_engineer(github: body["pull_request"]["user"]["login"])
           assignment_message = "#{chosen_reviewer} has been notified via round-robin to review #{body["pull_request"]["html_url"]}"
-          puts "Notifying #{pr_owner} of assignment."
+          puts "Notifying #{pr_owner[:usernames][:slack]} of assignment."
           send_dm(pr_owner[:usernames][:slack], assignment_message)
 
           response

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -167,7 +167,7 @@ module Lita
           puts "Notifying PR owner of assignment..."
           pr_owner = find_engineer(github: body["pull_request"]["user"]["login"])
           assignment_message = "We assigned #{chosen_reviewer} to review #{body["pull_request"]["html_url"]}"
-          send_dm(engineer[:usernames][:slack], assignment_message)
+          send_dm(pr_owner[:usernames][:slack], assignment_message)
 
           response
         end

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -164,6 +164,11 @@ module Lita
           puts "Sending DM to #{chosen_reviewer}..."
           send_dm(chosen_reviewer, message)
 
+          puts "Notifying PR owner of assignment..."
+          pr_owner = find_engineer(github: body["pull_request"]["user"]["login"])
+          assignment_message = "We assigned #{chosen_reviewer} to review #{body["pull_request"]["html_url"]}"
+          send_dm(engineer[:usernames][:slack], assignment_message)
+
           response
         end
       end

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -164,9 +164,9 @@ module Lita
           puts "Sending DM to #{chosen_reviewer}..."
           send_dm(chosen_reviewer, message)
 
-          puts "Notifying PR owner of assignment..."
           pr_owner = find_engineer(github: body["pull_request"]["user"]["login"])
-          assignment_message = "We assigned #{chosen_reviewer} to review #{body["pull_request"]["html_url"]}"
+          assignment_message = "#{chosen_reviewer} has been notified via round-robin to review #{body["pull_request"]["html_url"]}"
+          puts "Notifying #{pr_owner} of assignment."
           send_dm(pr_owner[:usernames][:slack], assignment_message)
 
           response

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.7.4"
+  spec.version       = "0.7.5"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."


### PR DESCRIPTION
Suggestion from one of the engineers. 

- Inform the PR owner that their PR was assigned to someone.