### PR TITLE
owner assignment and label improvements

### DIFF
--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -135,6 +135,8 @@ module Lita
           return
         end
 
+        p body["pull_request"]
+
         if body["labels"].none? { |label| label.name.downcase.include?('review') }
           puts 'Labels do not include a review label, exiting...'
           return

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -135,7 +135,7 @@ module Lita
           return
         end
 
-        if body["pull_request"]["labels"].none? { |label| label.name.downcase.include?('review') }
+        if body["pull_request"]["labels"].none? { |label| label["name"].downcase.include?('review') }
           puts 'Labels do not include a review label, exiting...'
           return
         end

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -135,9 +135,7 @@ module Lita
           return
         end
 
-        p body["pull_request"]
-
-        if body["labels"].none? { |label| label.name.downcase.include?('review') }
+        if body["pull_request"]["labels"].none? { |label| label.name.downcase.include?('review') }
           puts 'Labels do not include a review label, exiting...'
           return
         end

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -161,11 +161,11 @@ module Lita
           message_for_owner = "#{chosen_reviewer} has been notified via round-robin to review #{body["pull_request"]["html_url"]}"
 
           puts "Sending DM to #{chosen_reviewer}..."
-          send_dm(chosen_reviewer, message)
+          send_dm(chosen_reviewer, message_for_reviewer)
 
           if pr_owner
             puts "Notifying #{pr_owner} of assignment."
-            send_dm(pr_owner, assignment_message)
+            send_dm(pr_owner, message_for_owner)
           else
             puts "Couldn't find a config for pr owner #{body["pull_request"]["user"]["login"]}. Make sure they are in the lita config!"
             puts "Skipping notifying PR owner of RR assignment."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.7.9"
+  spec.version       = "0.8.0"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.7.6"
+  spec.version       = "0.7.7"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.7.7"
+  spec.version       = "0.7.8"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.7.5"
+  spec.version       = "0.7.6"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.7.8"
+  spec.version       = "0.7.9"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."


### PR DESCRIPTION
1. Assign round robin reviewers when someone applies the "Review" label instead of on PR open
2. Don't assign the person who created the PR