### PR TITLE
Stop pinging about edited comments

### DIFF
--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -54,7 +54,7 @@ module Lita
         puts body["action"]
         puts body["state"]
 
-        if body["comment"]
+        if body["comment"] && body["action"] == "created"
           act_on_comment(body, response)
         end
 


### PR DESCRIPTION
For some reason we were missing this little bit, which resulted in comments being acted upon when the action was `"edited"`. This stops that and only pings when the action is `"created"`