### PR TITLE
Prevent multiple review request notifications when assigning more than one reviewer at the same time

### DIFF
--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -165,30 +165,28 @@ module Lita
       def act_on_review_requested(body, response)
         puts "Detected a review request."
 
-        reviewers = body["pull_request"]["requested_reviewers"]
+        reviewer = body["pull_request"]["requested_reviewer"]
 
-        reviewers.each do |reviewer|
-          engineer = find_engineer(github: reviewer["login"])
+        engineer = find_engineer(github: reviewer["login"])
 
-          if engineer
-            puts "#{engineer} determined as a reviewer."
+        if engineer
+          puts "#{engineer} determined as a reviewer."
 
-            puts "Looking up preferences..."
-            should_notify = engineer[:github_preferences][:notify_about_review_requests]
+          puts "Looking up preferences..."
+          should_notify = engineer[:github_preferences][:notify_about_review_requests]
 
-            if !should_notify
-              puts "will not notify, preference for :github_preferences[:notify_about_review_requests] is not true"
-            else
-              url = body["pull_request"]["html_url"]
-
-              message = "You've been asked to review a pull request:\n#{url}"
-
-              puts "Sending DM to #{engineer}..."
-              send_dm(engineer[:usernames][:slack], message)
-            end
+          if !should_notify
+            puts "will not notify, preference for :github_preferences[:notify_about_review_requests] is not true"
           else
-            puts "Could not find engineer #{reviewer["login"]}"
+            url = body["pull_request"]["html_url"]
+
+            message = "You've been asked to review a pull request:\n#{url}"
+
+            puts "Sending DM to #{engineer}..."
+            send_dm(engineer[:usernames][:slack], message)
           end
+        else
+          puts "Could not find engineer #{reviewer["login"]}"
         end
 
         response

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.9.4"
+  spec.version       = "0.9.5"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."


### PR DESCRIPTION
We had a bug where if I requested reviews from three different people, each reviewer would then get three notifications to review the PR.

I deduced this is because GitHub sends three different `review_requested` web hooks when this kind of thing happens, each with the same `requested_reviewers` data (that was the bug), but with a different `requested_reviewer` (that's the fix). Whoops!