### PR TITLE
Actually fix the multiple review request bug

### DIFF
--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -165,30 +165,28 @@ module Lita
       def act_on_review_requested(body, response)
         puts "Detected a review request."
 
-        reviewers = body["pull_request"]["requested_reviewers"]
+        reviewer = body["pull_request"]["requested_reviewer"]
 
-        reviewers.each do |reviewer|
-          engineer = find_engineer(github: reviewer["login"])
+        engineer = find_engineer(github: reviewer["login"])
 
-          if engineer
-            puts "#{engineer} determined as a reviewer."
+        if engineer
+          puts "#{engineer} determined as a reviewer."
 
-            puts "Looking up preferences..."
-            should_notify = engineer[:github_preferences][:notify_about_review_requests]
+          puts "Looking up preferences..."
+          should_notify = engineer[:github_preferences][:notify_about_review_requests]
 
-            if !should_notify
-              puts "will not notify, preference for :github_preferences[:notify_about_review_requests] is not true"
-            else
-              url = body["pull_request"]["html_url"]
-
-              message = "You've been asked to review a pull request:\n#{url}"
-
-              puts "Sending DM to #{engineer}..."
-              send_dm(engineer[:usernames][:slack], message)
-            end
+          if !should_notify
+            puts "will not notify, preference for :github_preferences[:notify_about_review_requests] is not true"
           else
-            puts "Could not find engineer #{reviewer["login"]}"
+            url = body["pull_request"]["html_url"]
+
+            message = "You've been asked to review a pull request:\n#{url}"
+
+            puts "Sending DM to #{engineer}..."
+            send_dm(engineer[:usernames][:slack], message)
           end
+        else
+          puts "Could not find engineer #{reviewer["login"]}"
         end
 
         response

--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -165,6 +165,8 @@ module Lita
       def act_on_review_requested(body, response)
         puts "Detected a review request."
 
+        p body["pull_request"]
+
         reviewer = body["pull_request"]["requested_reviewer"]
 
         engineer = find_engineer(github: reviewer["login"])

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.9.5"
+  spec.version       = "0.9.6"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.9.4"
+  spec.version       = "0.9.5"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."

--- a/lita-github-pinger.gemspec
+++ b/lita-github-pinger.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-github-pinger"
-  spec.version       = "0.9.6"
+  spec.version       = "0.9.7"
   spec.authors       = ["Taylor Lapeyre"]
   spec.email         = ["taylorlapeyre@gmail.com"]
   spec.description   = "A Lita handler that detects github comment notifications and regurgitates a ping to the correct slack username."


### PR DESCRIPTION
Turns out the previous fix just kinda caused an error and this fix actually works. With this change, you will only ever get pinged to assign a PR once. After that first ping, you will never be notified to review it again.

Not a perfectly correct solution, but hey, a man can only take so much robot notifications tweaking